### PR TITLE
Enable AudioUnit's input only when inputs > 0

### DIFF
--- a/architecture/faust/audio/coreaudio-ios-dsp.h
+++ b/architecture/faust/audio/coreaudio-ios-dsp.h
@@ -471,7 +471,11 @@ class TiPhoneCoreAudioRenderer
                 goto error;
             }
 
-            enableIO = 1;
+            if (fDevNumInChans > 0) {
+                enableIO = 1;
+            } else {
+                enableIO = 0;
+            }
             err = AudioUnitSetProperty(fAUHAL, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Input, 1, &enableIO, sizeof(enableIO));
             if (err != noErr) {
                 printf("Error calling AudioUnitSetProperty - kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Input\n");


### PR DESCRIPTION
closes #457

The issue seems to be somehow related to this: https://stackoverflow.com/questions/21337276/ios-app-asks-for-microphone-access-even-for-kaudiosessioncategory-mediaplayback
and this: https://github.com/alexbw/novocaine/issues/76